### PR TITLE
Fix: set Node.js heap limit to prevent OOM crashes

### DIFF
--- a/docker-compose.scaleway.yml
+++ b/docker-compose.scaleway.yml
@@ -8,6 +8,12 @@ services:
     ports:
       - "127.0.0.1:8083:8083"
     env_file: .env
+    environment:
+      NODE_OPTIONS: "--max-old-space-size=2048"
+    deploy:
+      resources:
+        limits:
+          memory: 2560m
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary
- Set `NODE_OPTIONS: --max-old-space-size=2048` for the backend container
- Add container memory limit of 2560MB to prevent one service from starving the VM
- Fixes OOM crash caused by burst of concurrent `/client-narratives` and `/client-fragments` requests

## Test plan
- [ ] Deploy to Scaleway and verify backend starts correctly
- [ ] Monitor memory usage under normal traffic
- [ ] Confirm no more `FATAL ERROR: Reached heap limit` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)