### PR TITLE
fix: pre-serialize API responses to prevent OOM from concurrent JSON.…

### DIFF
--- a/cd_backend/src/domain/fragments/getCachedClientFragments.ts
+++ b/cd_backend/src/domain/fragments/getCachedClientFragments.ts
@@ -332,7 +332,9 @@ const createGetCachedClientFragments = ({ dbConnection }: { dbConnection: DataSo
       });
   }
 
-  return async (params: { languageCode: string; page?: number; limit?: number }) => {
+  const serializedMap = new Map<string, { json: string; etag: string; dataRef: unknown }>();
+
+  return async (params: { languageCode: string; page?: number; limit?: number }): Promise<{ json: string; etag: string }> => {
     const startTime = Date.now();
 
     const CACHE_INVALIDATION_TIMESTAMP = '20230705-fragment-ids-cache';
@@ -343,7 +345,18 @@ const createGetCachedClientFragments = ({ dbConnection }: { dbConnection: DataSo
     const totalTime = Date.now() - startTime;
     logSlowQueries(totalTime, `getClientFragments(${JSON.stringify(params)})`, 500);
 
-    return result;
+    const mapKey = JSON.stringify(params);
+    const cached = serializedMap.get(mapKey);
+
+    if (cached && cached.dataRef === result) {
+      return { json: cached.json, etag: cached.etag };
+    }
+
+    const json = JSON.stringify(result);
+    const etag = `W/"${Buffer.byteLength(json).toString(16)}"`;
+    serializedMap.set(mapKey, { json, etag, dataRef: result });
+
+    return { json, etag };
   };
 };
 

--- a/cd_backend/src/domain/fragments/getCachedClientFragments.ts
+++ b/cd_backend/src/domain/fragments/getCachedClientFragments.ts
@@ -334,7 +334,11 @@ const createGetCachedClientFragments = ({ dbConnection }: { dbConnection: DataSo
 
   const serializedMap = new Map<string, { json: string; etag: string; dataRef: unknown }>();
 
-  return async (params: { languageCode: string; page?: number; limit?: number }): Promise<{ json: string; etag: string }> => {
+  return async (params: {
+    languageCode: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ json: string; etag: string }> => {
     const startTime = Date.now();
 
     const CACHE_INVALIDATION_TIMESTAMP = '20230705-fragment-ids-cache';

--- a/cd_backend/src/domain/narratives/getCachedClientNarratives.ts
+++ b/cd_backend/src/domain/narratives/getCachedClientNarratives.ts
@@ -204,20 +204,33 @@ function formatNarrativeResponse(
   };
 }
 
+export type PreSerializedResponse = { json: string; etag: string };
+
 export type GetCachedClientNarratives = ReturnType<typeof createGetCachedClientNarratives>;
 
 const createGetCachedClientNarratives = ({ dbConnection }: { dbConnection: DataSource }) => {
-  // Improved caching with shorter TTL but longer stale time to reduce database pressure
   const cache = createCache({
-    ttl: 30 * 60, // 30 minutes fresh cache
-    stale: 3 * 60 * 60, // 3 hours stale cache
+    ttl: 30 * 60,
+    stale: 3 * 60 * 60,
     storage: {
       type: 'memory',
     },
   }).define('getClientNarratives', getClientNarratives({ dbConnection }));
 
-  return async () => {
-    return await cache.getClientNarratives();
+  let serialized: PreSerializedResponse | null = null;
+  let lastDataRef: unknown = null;
+
+  return async (): Promise<PreSerializedResponse> => {
+    const data = await cache.getClientNarratives();
+
+    if (data !== lastDataRef || !serialized) {
+      const json = JSON.stringify(data);
+      const etag = `W/"${Buffer.byteLength(json).toString(16)}"`;
+      serialized = { json, etag };
+      lastDataRef = data;
+    }
+
+    return serialized;
   };
 };
 

--- a/cd_backend/src/domain/tagCategories/getCachedClientTagCategories.ts
+++ b/cd_backend/src/domain/tagCategories/getCachedClientTagCategories.ts
@@ -77,23 +77,33 @@ const createGetCachedClientTagCategories = ({ dbConnection }: { dbConnection: Da
     },
   }).define('getTagCategories', getTagCategories({ dbConnection }));
 
-  return async (languageCode: string): Promise<TagCategoryWithTags[]> => {
+  const serializedMap = new Map<string, { json: string; etag: string; dataRef: unknown }>();
+
+  return async (languageCode: string): Promise<{ json: string; etag: string }> => {
     const startTime = Date.now();
 
-    // Cache invalidation for the query change with optimized implementation
     const CACHE_INVALIDATION_TIMESTAMP = '20240319-tag-categories-cache';
     const cacheKey = JSON.stringify({ languageCode, _cacheInvalidation: CACHE_INVALIDATION_TIMESTAMP });
 
     const result = await cache.getTagCategories(cacheKey);
 
-    // Log performance metrics for slow queries (>500ms)
     const totalTime = Date.now() - startTime;
     if (totalTime > 500) {
       // eslint-disable-next-line no-console
       console.warn(`SLOW QUERY (${totalTime}ms): getCachedClientTagCategories(${languageCode})`);
     }
 
-    return result;
+    const cached = serializedMap.get(languageCode);
+
+    if (cached && cached.dataRef === result) {
+      return { json: cached.json, etag: cached.etag };
+    }
+
+    const json = JSON.stringify({ tagCategories: result });
+    const etag = `W/"${Buffer.byteLength(json).toString(16)}"`;
+    serializedMap.set(languageCode, { json, etag, dataRef: result });
+
+    return { json, etag };
   };
 };
 

--- a/cd_backend/src/http/client/getClientFragments.ctrl.ts
+++ b/cd_backend/src/http/client/getClientFragments.ctrl.ts
@@ -41,12 +41,11 @@ export const registerGetClientFragmentsController =
           return res.status(304).send(null);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return res
+        res
           .status(200)
           .type('application/json')
-          .serializer(() => json)
-          .send(json as any);
+          .serializer(() => json);
+        return res.send(json as never);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientFragments.ctrl.ts
+++ b/cd_backend/src/http/client/getClientFragments.ctrl.ts
@@ -42,7 +42,11 @@ export const registerGetClientFragmentsController =
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return res.status(200).type('application/json').serializer(() => json).send(json as any);
+        return res
+          .status(200)
+          .type('application/json')
+          .serializer(() => json)
+          .send(json as any);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientFragments.ctrl.ts
+++ b/cd_backend/src/http/client/getClientFragments.ctrl.ts
@@ -26,30 +26,23 @@ export const registerGetClientFragmentsController =
         const validatedLimit = Math.min(limit, 500);
         const validatedPage = Math.max(page, 1);
 
-        const clientFragments = await getCachedClientFragments({
+        const { json, etag } = await getCachedClientFragments({
           languageCode,
           page: validatedPage,
           limit: validatedLimit,
         });
 
-        // eslint-disable-next-line no-console
-        console.log({ len: clientFragments.data.length });
-
-        // Add cache headers to improve client-side caching
         res.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=3600');
         res.header('Vary', 'Accept-Encoding, Accept-Language');
-
-        // Generate ETag for efficient caching
-        const etag = `W/"${Buffer.from(JSON.stringify(clientFragments)).length.toString(16)}"`;
         res.header('ETag', etag);
 
-        // Check if client has a fresh copy (304 Not Modified)
         const ifNoneMatch = req.headers['if-none-match'];
         if (ifNoneMatch === etag) {
           return res.status(304).send(null);
         }
 
-        return res.status(200).send(clientFragments);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return res.status(200).type('application/json').serializer(() => json).send(json as any);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientNarratives.ctrl.ts
+++ b/cd_backend/src/http/client/getClientNarratives.ctrl.ts
@@ -23,13 +23,11 @@ export const registerGetClientNarrativesController =
           return res.status(304).send(null);
         }
 
-        // Pre-serialized JSON string — serializer(() => json) bypasses Fastify's schema serializer
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return res
+        res
           .status(200)
           .type('application/json')
-          .serializer(() => json)
-          .send(json as any);
+          .serializer(() => json);
+        return res.send(json as never);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientNarratives.ctrl.ts
+++ b/cd_backend/src/http/client/getClientNarratives.ctrl.ts
@@ -12,23 +12,20 @@ export const registerGetClientNarrativesController =
       preHandler: [requireApiKey('read:client-protected')],
       schema: getClientNarrativesSchema(),
       handler: async (req, res) => {
-        const clientNarratives = await getCachedClientNarratives();
+        const { json, etag } = await getCachedClientNarratives();
 
-        // Add cache headers to improve client-side caching
         res.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=3600');
         res.header('Vary', 'Accept-Encoding');
-
-        // Generate ETag for efficient caching
-        const etag = `W/"${Buffer.from(JSON.stringify(clientNarratives)).length.toString(16)}"`;
         res.header('ETag', etag);
 
-        // Check if client has a fresh copy (304 Not Modified)
         const ifNoneMatch = req.headers['if-none-match'];
         if (ifNoneMatch === etag) {
           return res.status(304).send(null);
         }
 
-        return res.status(200).send(clientNarratives);
+        // Pre-serialized JSON string — serializer(() => json) bypasses Fastify's schema serializer
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return res.status(200).type('application/json').serializer(() => json).send(json as any);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientNarratives.ctrl.ts
+++ b/cd_backend/src/http/client/getClientNarratives.ctrl.ts
@@ -25,7 +25,11 @@ export const registerGetClientNarrativesController =
 
         // Pre-serialized JSON string — serializer(() => json) bypasses Fastify's schema serializer
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return res.status(200).type('application/json').serializer(() => json).send(json as any);
+        return res
+          .status(200)
+          .type('application/json')
+          .serializer(() => json)
+          .send(json as any);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientTagCategories.ctrl.ts
+++ b/cd_backend/src/http/client/getClientTagCategories.ctrl.ts
@@ -27,12 +27,11 @@ export const registerGetClientTagCategoriesController =
           return res.status(304).send(null);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return res
+        res
           .status(200)
           .type('application/json')
-          .serializer(() => json)
-          .send(json as any);
+          .serializer(() => json);
+        return res.send(json as never);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientTagCategories.ctrl.ts
+++ b/cd_backend/src/http/client/getClientTagCategories.ctrl.ts
@@ -16,23 +16,19 @@ export const registerGetClientTagCategoriesController =
           languageCode?: string;
         };
 
-        const tagCategories = await getCachedClientTagCategories(languageCode);
+        const { json, etag } = await getCachedClientTagCategories(languageCode);
 
-        // Add cache headers to improve client-side caching
         res.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=3600');
         res.header('Vary', 'Accept-Encoding, Accept-Language');
-
-        // Generate ETag for efficient caching
-        const etag = `W/"${Buffer.from(JSON.stringify(tagCategories)).length.toString(16)}"`;
         res.header('ETag', etag);
 
-        // Check if client has a fresh copy (304 Not Modified)
         const ifNoneMatch = req.headers['if-none-match'];
         if (ifNoneMatch === etag) {
           return res.status(304).send(null);
         }
 
-        return res.status(200).send({ tagCategories });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return res.status(200).type('application/json').serializer(() => json).send(json as any);
       },
     });
   };

--- a/cd_backend/src/http/client/getClientTagCategories.ctrl.ts
+++ b/cd_backend/src/http/client/getClientTagCategories.ctrl.ts
@@ -28,7 +28,11 @@ export const registerGetClientTagCategoriesController =
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return res.status(200).type('application/json').serializer(() => json).send(json as any);
+        return res
+          .status(200)
+          .type('application/json')
+          .serializer(() => json)
+          .send(json as any);
       },
     });
   };


### PR DESCRIPTION
…stringify

Cache JSON string + ETag at cache layer so concurrent requests share one serialized copy instead of each running JSON.stringify independently. Removes debug console.log from fragments controller.