### PR TITLE
fix: mount Scaleway DB CA cert so TLS verifies after Neon migration

### DIFF
--- a/docker-compose.scaleway.yml
+++ b/docker-compose.scaleway.yml
@@ -10,6 +10,11 @@ services:
     env_file: .env
     environment:
       NODE_OPTIONS: "--max-old-space-size=2048"
+      # Trust Scaleway managed-PG self-signed cert so TypeORM's rejectUnauthorized:true verifies.
+      # scaleway-ca.pem is a persistent untracked artifact in /opt/cd_admin (like .env).
+      NODE_EXTRA_CA_CERTS: /etc/ssl/scaleway-ca.pem
+    volumes:
+      - ./scaleway-ca.pem:/etc/ssl/scaleway-ca.pem:ro
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## What
Mounts the Scaleway managed-PostgreSQL TLS cert into the `cd_backend` container and points Node's `NODE_EXTRA_CA_CERTS` at it.

## Why
We migrated the DB from Neon → Scaleway managed PostgreSQL. Scaleway's DB endpoint presents a **self-signed** cert (`DEPTH_ZERO_SELF_SIGNED_CERT`, issuer `O=Scaleway`). The backend's TypeORM config uses `ssl.rejectUnauthorized: true`, so connections were rejected. Pinning the cert via `NODE_EXTRA_CA_CERTS` makes verify-full pass — **no code change**. We connect by the DNS hostname `rw-<id>.rdb.fr-par.scw.cloud`, which is in the cert SAN.

## ⚠️ Deploy prerequisite
The compose mounts `./scaleway-ca.pem` (resolves to `/opt/cd_admin/scaleway-ca.pem`), a **persistent untracked server artifact** like `.env`. It already exists on the prod instance. If the instance is ever re-provisioned, re-create it:
```
echo | openssl s_client -starttls postgres -connect rw-9a371550-1189-4926-91b6-aff7c59869fc.rdb.fr-par.scw.cloud:26720 2>/dev/null | openssl x509 -outform pem > /opt/cd_admin/scaleway-ca.pem
```

## ⚠️ Merge urgency
The prod backend already runs with this mount (applied manually). This PR makes it permanent so the deploy's `git reset --hard origin/main` doesn't wipe it. **Merge before any other deploy to main**, or the DB connection breaks.

## Note
Cert is self-signed and could be rotated/renewed by Scaleway. If the DB connection later fails on TLS, re-export the cert (command above). Check expiry: `openssl x509 -in /opt/cd_admin/scaleway-ca.pem -noout -enddate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)