### PR TITLE
feat: deploy photobooth kiosk to production

### DIFF
--- a/docker-compose.scaleway.yml
+++ b/docker-compose.scaleway.yml
@@ -43,6 +43,24 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  cd_photobooth:
+    build:
+      context: ./cd_photobooth
+      dockerfile: Dockerfile
+      target: production
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+        VITE_API_KEY: ${PHOTOBOOTH_API_KEY}
+        VITE_STORAGE_PULL_ZONE: ${BUNNY_STORAGE_PULL_ZONE}
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${PHOTOBOOTH_PORT}:80"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   promtail:
     image: grafana/promtail:latest
     restart: unless-stopped


### PR DESCRIPTION
## Summary
Adds the `cd_photobooth` kiosk SPA to `docker-compose.scaleway.yml` so it builds and runs on the production VM alongside `cd_backend` and `cd_cms`.

- Mirrors the `cd_cms` service: `production` target, `VITE_*` build args, bound to `127.0.0.1:${PHOTOBOOTH_PORT}` for the host reverse proxy.
- Build args reuse existing prod env (`PHOTOBOOTH_API_KEY`, `BUNNY_STORAGE_PULL_ZONE`).

## VM prerequisites before merge/deploy
Add to `/opt/cd_admin.env` on the VM:
- `VITE_API_BASE_URL` — public backend URL the kiosk calls
- `PHOTOBOOTH_PORT` — free localhost port for the kiosk container

## Post-deploy (host-side, not in this repo)
- Reverse-proxy route: `<kiosk-domain>` → `127.0.0.1:${PHOTOBOOTH_PORT}` + TLS
- DNS record for the kiosk subdomain → VM IP

## Notes
- Production-target image build verified locally.
- Empty env won't break the existing stack (port falls back to ephemeral), so this won't trigger a backend rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)