### PR TITLE
fix: populate person/country in unfiltered GET /fragments

### DIFF
--- a/cd_backend/src/domain/fragments/getFragments.ts
+++ b/cd_backend/src/domain/fragments/getFragments.ts
@@ -11,10 +11,19 @@ async function getFragments({
   dbConnection: DataSource;
   personIds?: string[];
 }): Promise<FragmentPayload[]> {
-  const queryBuilder = dbConnection.getRepository(FragmentEntity).createQueryBuilder('fragment');
+  const queryBuilder = dbConnection
+    .getRepository(FragmentEntity)
+    .createQueryBuilder('fragment')
+    // Always load person + country so the endpoint honors its schema. Previously these
+    // were only joined when filtering by personIds, so an unfiltered GET /fragments
+    // returned person:null for every fragment even when links existed in the DB — which
+    // left the Videos panel person/country filters empty.
+    .leftJoinAndSelect('fragment.person', 'person')
+    .leftJoinAndSelect('person.country', 'country')
+    .leftJoinAndSelect('country.names', 'countryNames');
 
   if (personIds && personIds.length > 0) {
-    queryBuilder.leftJoinAndSelect('fragment.person', 'person').andWhere('person.id IN (:...personIds)', { personIds });
+    queryBuilder.andWhere('person.id IN (:...personIds)', { personIds });
   }
 
   const dbFragments = await queryBuilder.getMany();

--- a/cd_backend/src/http/fragments/getFragments.ctrl.spec.ts
+++ b/cd_backend/src/http/fragments/getFragments.ctrl.spec.ts
@@ -80,6 +80,30 @@ describe('GET /fragments', () => {
     ]);
   });
 
+  it('should include the linked person without a personIds filter', async () => {
+    const testApp = await setupTestApp();
+    const authToken = testApp.createAuthToken();
+
+    const guid1 = uuid4();
+    const guid2 = uuid4();
+    const personIds = await testDb.saveTestPersons(['Linked Person']);
+
+    await testDb.saveTestFragments([
+      { guid: guid1, title: 'Has Person', length: 1, personId: personIds[0] },
+      { guid: guid2, title: 'No Person', length: 2 },
+    ]);
+
+    const res = await testApp
+      .request()
+      .get('/fragments')
+      .headers({ Authorization: `Bearer ${authToken}` })
+      .end();
+
+    const byId = Object.fromEntries(res.json().data.map((item: any) => [item.id, item.attributes.person]));
+    expect(byId[guid1]).to.deep.equal({ id: personIds[0], name: 'Linked Person' });
+    expect(byId[guid2]).to.equal(null);
+  });
+
   it('should filter fragments by person', async () => {
     const testApp = await setupTestApp();
     const authToken = testApp.createAuthToken();


### PR DESCRIPTION
## Problem
The Videos panel person/country filters are empty in production even though prod's DB has the links (verified: `/client-fragments` returns 396 fragments all with a person).

Root cause: `getFragments` only joined `fragment.person` **inside** the `if (personIds)` branch. An unfiltered `GET /fragments` (used by the Videos panel's `getVideoMeta`) ran a plain `getMany()` with no relations, so `parseFragmentEntity` saw `fragment.person === undefined` → returned `person:null`/`country:null` for every fragment. The client narratives/free-browsing payloads show persons only because they explicitly `leftJoin('fragment.person')`.

## Fix
Always `leftJoinAndSelect` `person` + `person.country` + `country.names` in `getFragments`; keep the `personIds` filter as an additional `WHERE`. No change to tags/narratives behavior.

## Tests
- Existing: unfiltered (no persons assigned) still `person:null`; `personIds` filter still works.
- New: unfiltered request now returns the linked person and `null` for unlinked fragments.
- typecheck + lint + integration (155 passing) green.

## Note
Independent of the dev Neon restore (that's only for local data). This fix makes the prod filters work since prod already has the links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)