### PR TITLE
feat: USE_LOCAL_POSTGRES path for offline local dev

### DIFF
--- a/cd_backend/.env.example
+++ b/cd_backend/.env.example
@@ -17,6 +17,15 @@ NEON_DB_PASSWORD=your_password
 NEON_DB_DATABASE=your_database_name
 NEON_DB_SSL=true
 
+# Local Postgres for offline dev against a restored prod dump.
+# Set USE_NEON_DB=false and USE_LOCAL_POSTGRES=true to use the docker-compose `postgres`
+# service instead of Neon/SQLite. DB_* default to the compose service values below.
+USE_LOCAL_POSTGRES=false
+DB_HOST=postgres
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+
 # Server Configuration
 BACKEND_HOST=cd_backend
 BACKEND_PORT=8083

--- a/cd_backend/src/db/dbConfig.ts
+++ b/cd_backend/src/db/dbConfig.ts
@@ -36,6 +36,24 @@ export function getDataSourceOptions(): DataSourceOptions {
     } as DataSourceOptions;
   }
 
+  // Local Postgres (docker-compose `postgres` service) — for offline dev against a
+  // restored prod dump. No SSL.
+  if (ENV.USE_LOCAL_POSTGRES) {
+    return {
+      type: 'postgres',
+      host: ENV.DB_HOST,
+      port: parseInt(ENV.DB_PORT || '5432'),
+      username: ENV.DB_USERNAME,
+      password: ENV.DB_PASSWORD,
+      database: ENV.DB_DATABASE,
+      synchronize: false,
+      logging: ['error', 'schema', 'warn', 'info'],
+      entities: [`${__dirname}/entities/*.{js,ts}`],
+      migrations: [`${__dirname}/migrations/*.{js,ts}`],
+      migrationsRun: true,
+    } as DataSourceOptions;
+  }
+
   // Default SQLite configuration
   return {
     type: 'sqlite',

--- a/cd_backend/src/env.ts
+++ b/cd_backend/src/env.ts
@@ -27,6 +27,17 @@ const envSchema = z.object({
     .transform((val) => val === 'true')
     .default('true'),
 
+  // Local Postgres (e.g. the docker-compose `postgres` service) for offline dev with a
+  // restored prod dump. Defaults make `.env` only need USE_LOCAL_POSTGRES=true.
+  USE_LOCAL_POSTGRES: z
+    .string()
+    .transform((val) => val === 'true')
+    .default('false'),
+  DB_HOST: z.string().optional().default('postgres'),
+  DB_PORT: z.string().optional().default('5432'),
+  DB_USERNAME: z.string().optional().default('postgres'),
+  DB_PASSWORD: z.string().optional().default('postgres'),
+
   BUNNY_STREAM_BASE_URL: z.string(),
   BUNNY_STREAM_API_KEY: z.string(),
   BUNNY_STREAM_LIBRARY_ID: z.string(),


### PR DESCRIPTION
## Summary
Lets the dev backend run fully offline against a **local Postgres** (the docker-compose `postgres` service) loaded from a prod `pg_dump`, instead of the only prior options — remote Neon or local SQLite (which can't ingest a pg dump).

## Changes
- `dbConfig.ts`: new branch — when `USE_LOCAL_POSTGRES=true` (and not Neon), connect to `DB_HOST/PORT/USERNAME/PASSWORD/DB_DATABASE` over plain (no SSL). Neon and SQLite paths unchanged; the integration-test datasource (explicit overrides via `createDbConnection`) is unaffected.
- `env.ts`: add `USE_LOCAL_POSTGRES` + `DB_HOST/PORT/USERNAME/PASSWORD` with defaults matching the compose service, so `.env` only needs `USE_NEON_DB=false` + `USE_LOCAL_POSTGRES=true`.
- `.env.example`: document the new vars.

## Usage
```
docker compose up -d postgres
pg_restore --clean --if-exists --no-owner --no-acl -U postgres -d cd_backend <prod>.custom
# .env: USE_NEON_DB=false, USE_LOCAL_POSTGRES=true
docker compose up -d --force-recreate cd_backend
```

Verified locally: `/fragments` returns 398/417 fragments with person + country after restoring the prod dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)